### PR TITLE
Add padding to window list item box & Fix applet hover so box and text light up together

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -356,7 +356,7 @@ StScrollBar StButton#vhandle:hover
 .panel-corner:active,
 .panel-corner:overview,
 .panel-corner:focus {
-		border-image: url("button-prelight.png") 3 3 3 3 stretch stretch;
+    border-image: url("button-prelight.png") 3 3 3 3 stretch stretch;
     transition-duration: 50;
 }
 
@@ -2101,10 +2101,9 @@ max-height: 100px;
 }
 .applet-label {	
 	font-weight: bold;
-	color: #6EBEFE;		
+	color: #6EBEFE;
 }
-.applet-label:hover,
-.applet-box:hover > .applet-label {
+.applet-box:hover .applet-label {
 	color: #6EBEFE;
 	text-shadow: white 0px 0px 5px;
 }
@@ -2112,8 +2111,7 @@ max-height: 100px;
 	color: #6EBEFE;
 	icon-size: 22px;
 }
-.applet-icon:hover,
-.applet-box:hover > .applet-icon {
+.applet-box:hover .applet-icon {
 	color: #6EBEFE;
 	icon-shadow: white 0px 0px 3px;
 }

--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1686,7 +1686,7 @@ StScrollBar StButton#vhandle:hover
 	color:#6EBEFE;
     border-image: url("button-normal.png") 3 3 3 3 stretch stretch;
     margin: 0;
-    padding: 0;
+    padding: 3px;
 }
 
 .window-list-item-box:active,


### PR DESCRIPTION
The window list buttons looked really cramped and the icons are covering the left border. This padding helps to fix that

Before:
![image](https://user-images.githubusercontent.com/6352172/155615991-f94c273e-b006-4301-b52d-ff2e62dcabf8.png)


After:
![image](https://user-images.githubusercontent.com/6352172/155615943-49e7a6ae-d6a5-4e92-9f84-3f1ad3f328e5.png)
